### PR TITLE
Don't fail on unsupported modes

### DIFF
--- a/driver.go
+++ b/driver.go
@@ -85,7 +85,7 @@ func (d *bazelDriver) loadPackages(patterns ...string) (*driver.Response, error)
 	log.Printf("mode: %v", d.cfg.Mode)
 	unsupportedModes := d.cfg.Mode &^ supportedModes
 	if unsupportedModes != 0 {
-		return nil, fmt.Errorf("%v (%b) not implemented", unsupportedModes, unsupportedModes)
+		log.Printf("%v (%b) not implemented", unsupportedModes, unsupportedModes)
 	}
 
 	if len(patterns) == 0 {


### PR DESCRIPTION
`gopls` asks for:

	mode: LoadMode(NeedName|NeedFiles|NeedCompiledGoFiles|NeedImports|NeedDeps|NeedTypesSizes|Unknown)

which causes bazelpackagesdriver to error out with

	LoadMode(Unknown) (10000000000) not implemented

Just logging this instead of returning a hard error allows package loadig to continue. I haven't yet
observed problems with a combination of acme-lsp and gopls.